### PR TITLE
darwin build

### DIFF
--- a/openvpn/build/gentoo-config-0.9.8
+++ b/openvpn/build/gentoo-config-0.9.8
@@ -1,0 +1,194 @@
+#!/bin/sh
+# Copyright 1999-2005 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/dev-libs/openssl/files/gentoo.config-0.9.8,v 1.16 2007/04/01 11:03:52 vapier Exp $
+#
+# Openssl doesn't play along nicely with cross-compiling
+# like autotools based projects, so let's teach it new tricks.
+#
+# Review the bundled 'config' script to see why kind of targets
+# we can pass to the 'Configure' script.
+
+#@ALON: Add mingw support
+#@ALON: Add darwin support
+#@ALON: Remove bash so we can work on msys
+#@ALON: Set CHOST if missing
+#@ALON: Add SunOS support
+#@ALON: Add AIX support
+
+if gcc -v > /dev/null 2>&1; then
+    CHOST="${CHOST:-`gcc -dumpmachine`}"
+fi
+
+gcc_cc() {
+    [ -z "${GCC}" ] && echo "cc" || echo "gcc"
+}
+
+# Testing routines
+if [ "$1" = "test" ] ; then
+    for c in \
+        "arm-gentoo-linux-uclibc      |linux-generic32 -DL_ENDIAN" \
+        "armv5b-linux-gnu             |linux-generic32 -DB_ENDIAN" \
+        "x86_64-pc-linux-gnu          |linux-x86_64" \
+        "alphaev56-unknown-linux-gnu  |linux-alpha+bwx-gcc" \
+        "i686-pc-linux-gnu            |linux-elf" \
+        "whatever-gentoo-freebsdX.Y   |BSD-generic32" \
+        "i686-gentoo-freebsdX.Y       |BSD-x86-elf" \
+        "sparc64-alpha-freebsdX.Y     |BSD-sparc64" \
+        "ia64-gentoo-freebsd5.99234   |BSD-ia64" \
+        "x86_64-gentoo-freebsdX.Y     |BSD-x86_64" \
+        "hppa64-aldsF-linux-gnu5.3    |linux-generic32 -DB_ENDIAN" \
+        "powerpc-gentOO-linux-uclibc  |linux-ppc" \
+        "powerpc64-unk-linux-gnu      |linux-ppc64" \
+    ;do
+        CHOST=${c/|*}
+        ret_want=${c/*|}
+        ret_got=$(CHOST=${CHOST} "$0")
+
+        if [ ${ret_want} = "${ret_got}" ] ; then
+            echo "PASS: ${CHOST}"
+        else
+            echo "FAIL: ${CHOST}"
+            echo -e "\twanted: ${ret_want}"
+            echo -e "\twe got: ${ret_got}"
+        fi
+    done
+    exit 0
+fi
+[ -z "${CHOST}" -a -n "$1" ] && CHOST="$1"
+
+
+# Detect the operating system
+case "${CHOST}" in
+    i*86-*-mingw*|i*86-mingw*|mingw*)   system="mingw";;
+    x86_64-*-mingw*)    system="mingw64";;
+    *-linux*)       system="linux";;
+    *-freebsd*)     system="BSD";;
+    *-solaris*)
+        if [ -z "${OPENSSL_FORCE64BIT}" ]; then
+            system="solaris"
+        else
+            system="solaris64"
+        fi
+    ;;
+    *-aix*)
+        if [ -z "${OPENSSL_FORCE64BIT}" ]; then
+            system="aix"
+        else
+            system="aix64"
+        fi
+    ;;
+    *-hpux*)
+        system="hpux"
+    ;;
+    *-apple*)       system="darwin";;
+    *)          exit 0;;
+esac
+
+
+# Compiler munging
+compiler="gcc"
+if [ "${CC}" = "ccc" ] ; then
+    compiler="${CC}"
+fi
+
+
+# Detect target arch
+machine=""
+chost_machine=${CHOST%%-*}
+case ${system} in
+linux)
+    case ${chost_machine} in
+        alphaev56*)   machine=alpha+bwx-${compiler};;
+        alphaev[678]*)machine=alpha+bwx-${compiler};;
+        alpha*)       machine=alpha-${compiler};;
+        arm*b*)       machine="generic32 -DB_ENDIAN";;
+        arm*)         machine="generic32 -DL_ENDIAN";;
+    #   hppa64*)      machine=parisc64;;
+        hppa*)        machine="generic32 -DB_ENDIAN";;
+        i[0-9]86*)    machine=elf;;
+        ia64*)        machine=ia64;;
+        m68*)         machine="generic32 -DB_ENDIAN";;
+        mips*el*)     machine="generic32 -DL_ENDIAN";;
+        mips*)        machine="generic32 -DB_ENDIAN";;
+        ppc64*|powerpc64*)
+            if [ -z "${OPENSSL_FORCE32BIT}" ]; then
+                machine=ppc64
+            else
+                machine=ppc
+            fi
+        ;;
+        ppc|powerpc*)
+            if [ -z "${OPENSSL_FORCE64BIT}" ]; then
+                machine=ppc
+            else
+                machine=ppc64
+            fi
+        ;;
+    #   sh64*)        machine=elf;;
+        sh*b*)        machine="generic32 -DB_ENDIAN";;
+        sh*)          machine="generic32 -DL_ENDIAN";;
+        sparc*v7*)    machine="generic32 -DB_ENDIAN";;
+        sparc64*)     machine=sparcv9;;
+        sparc*)       machine=sparcv8;;
+        s390x*)       machine="generic64 -DB_ENDIAN";;
+        s390*)        machine="generic32 -DB_ENDIAN";;
+        x86_64*)
+            # Better cross compile... but...
+            if [ -z "${OPENSSL_FORCE32BIT}" ]; then
+                machine=x86_64
+            else
+                machine=generic32
+            fi
+        ;;
+    esac
+    ;;
+BSD)
+    case ${chost_machine} in
+        alpha*)       machine=generic64;;
+        i[6-9]86*)    machine=x86-elf;;
+        ia64*)        machine=ia64;;
+        sparc64*)     machine=sparc64;;
+        x86_64*)      machine=x86_64;;
+        *)            machine=generic32;;
+    esac
+    ;;
+darwin)
+    case ${chost_machine} in
+        i[6-9]86*)    machine=i386-cc;;
+        x86_64*)      system=darwin64; machine=x86_64-cc;;
+        powerpc64*)   system=darwin64; machine=ppc64-cc;;
+        powerpc*)     machine=ppc-cc;;
+        *)            machine=error;;
+    esac
+    ;;
+solaris2.8)
+    case "${chost_machine}" in
+        sparc)        machine="sparcv8-$(gcc_cc)";;
+    esac
+    ;;
+solaris*)
+    case "${chost_machine}" in
+        sparc)        machine="sparcv9-$(gcc_cc)";;
+        i386)
+            if [ -z "${OPENSSL_FORCE64BIT}" ]; then
+                machine="x86-$(gcc_cc)"
+            else
+                machine="x86_64-$(gcc_cc)"
+            fi
+        ;;
+    esac
+    ;;
+aix*)
+    machine="$(gcc_cc)"
+    ;;
+hpux*)
+    machine="$(gcc_cc)"
+    ;;
+esac
+
+
+# If we have something, show it
+if [ -n "${system}" ]; then
+    [ -n "${machine}" ] && echo ${system}-${machine} || echo ${system}
+fi


### PR DESCRIPTION
Me have some experience with building OpenVPN for major platforms with differents SSL library. The main issue I find in other code is that instead of ```make install``` to the correct location, developers tend to copy SSL library files around and give OpenVPN (or other tools) weird OPENSSL_CFLAGS that end up in the binary.
Therefore when me tried to build on OSX I kinda stumbled into the python script because all the usual mistakes were present. The massive changes were because me cannot enhance code when inconsistent. It should now work with python3 as well.
Your efforts to prepare OpenVPN for the post quantum world are highly appreciated and I input is meant to help you (and others) to deploy this VPN and test it in real world environments.

The following is summary of what me did to the build.py:

- refactor Python, pep8+flake8 the code
- add constants, avoid copying from ../.. and use absolute directories instead.
- recycle downloads - pull all before building
- commandline options --verbose --skip-* --prefix etc
- adapt OpenSSL build to mimic the openvpn-build/build behavior
  (./Configure instead of ./config)
- treat Darwin and Linux as Unix only minors (systemd stuff) are separated
- add system detection script (from openvpn-build) to find the correct
  OpenSSL ./Configure target

To use, on OSX install xcode then run ```python build.py --skip-test```

The tests (make test in OpenSSL) are broken, me did not investigate why. The produced OpenVPN binary responds happily to --help and --version on 10.11.6

I did not test the windows build (one machine at a time) but while porting me found that the windows-nsis build may not pick up the custom OpenSSL library. Usually me goes with mingw and build the OpenVPN windows installer in a linux environment.

please merge or pick cherries, no need for attribution for my inputs