### PR TITLE
Improve build system and fix #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ We also use the OpenSSL fork maintained by the Open Quantum Safe Project for the
 
 * https://github.com/open-quantum-safe/openssl
 
+Due to changes in the content of the upstream OQS OpenSSL fork, we are temporarily using a fork of that repo to fix the resulting build break. We will return to the official upstream branch when we migrate to the OpenSSL 1.1.1 fork.
+
+* https://github.com/kevinmkane/openssl
+
 ---
 
 ## Setup instructions


### PR DESCRIPTION
Fix build failures stemming from directories not existing ahead of time in the staging area by making sure all needed directories are created.

Note additional dependencies required in build.py's that are generally present in desktop Ubuntu but are not automatically present in Docker containers.

Automatically skip the Windows OpenVPN build without causing an error if any of the Windows-built OQS-OpenSSL DLL's aren't present. Print an informational message in this case to inform the user, but let them build Linux only if that's what they want.