### PR TITLE
Regex for checking 'root' access updated

### DIFF
--- a/pqap/resizeimage.pl
+++ b/pqap/resizeimage.pl
@@ -16,7 +16,7 @@ my $EXTRA_SPACE = 100*1024;
 
 my $who = `whoami`;
 
-if ($who !~ /root/)
+if ($who !~ /^root$/)
 {
 
 	print "This should be run as root or with the sudo command.\n";


### PR DESCRIPTION
Regex for checking 'root' access should have start and end bounds, otherwise it would match 'cuberoot' or 'rootbeer' also.